### PR TITLE
Timestamp tags

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,9 +6,10 @@ require 'kuby'
 
 Bundler::GemHelper.install_tasks
 
-task default: :spec
-
-desc 'Run specs'
-RSpec::Core::RakeTask.new do |t|
-  t.pattern = './spec/**/*_spec.rb'
+require "rake/testtask"
+Rake::TestTask.new(:test) do |t|
+  t.libs << "test"
+  t.libs << "lib"
+  t.test_files = FileList["test/**/*_test.rb"]
 end
+task :default => :test

--- a/kuby-core.gemspec
+++ b/kuby-core.gemspec
@@ -22,6 +22,10 @@ Gem::Specification.new do |s|
   s.add_dependency 'railties', '>= 5.1'
   s.add_dependency 'rouge', '~> 3.0'
 
+  s.add_development_dependency "bundler", "~> 2.0"
+  s.add_development_dependency "rake", "~> 10.0"
+  s.add_development_dependency "minitest", "~> 5.0"
+
   s.require_path = 'lib'
 
   s.files = Dir['{lib,spec}/**/*', 'Gemfile', 'LICENSE', 'CHANGELOG.md', 'README.md', 'Rakefile', 'kuby-core.gemspec']

--- a/lib/kuby/docker/timestamp_tag.rb
+++ b/lib/kuby/docker/timestamp_tag.rb
@@ -1,13 +1,13 @@
 module Kuby
   module Docker
     class TimestampTag
-      RE = /20[\d]{2}(?:0[1-9]|11|12)(?:0[1-9]|1[1-9]|2[1-9]|3[01])/.freeze
       FORMAT = '%Y%m%d%H%M%S'.freeze
 
       def self.try_parse(str)
-        if str =~ RE
-          new(Time.strptime(str, FORMAT))
-        end
+        return nil unless str
+
+        new(Time.strptime(str, FORMAT))
+      rescue ArgumentError
       end
 
       attr_reader :time

--- a/test/models/timestamp_tag_test.rb
+++ b/test/models/timestamp_tag_test.rb
@@ -1,0 +1,17 @@
+require "test_helper"
+require 'time'
+
+class TimestampTagTest < Minitest::Test
+
+  def test_try_parse_returns_tag_if_input_is_valid_timestamp
+    assert Kuby::Docker::TimestampTag.try_parse("20200810165134")
+  end
+
+  def test_try_parse_returns_nil_on_nil
+    assert_nil Kuby::Docker::TimestampTag.try_parse(nil)
+  end
+
+  def test_try_parse_returns_nil_on_invalid_timestamp
+    assert_nil Kuby::Docker::TimestampTag.try_parse("2020")
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,4 @@
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
+
+require "kuby"
+require "minitest/autorun"


### PR DESCRIPTION
My deploy step told me that there were no tags. After debugging I found that the regex in `try_parse` filtered my tags out.

This should work just the same, without the regex.

Also setup very basic tests.