### PR TITLE
feat: added method for generating uniq hash

### DIFF
--- a/lib/kuby/kubernetes/provider.rb
+++ b/lib/kuby/kubernetes/provider.rb
@@ -1,5 +1,6 @@
 # typed: true
 require 'kubernetes-cli'
+require 'digest'
 
 module Kuby
   module Kubernetes
@@ -76,6 +77,10 @@ module Kuby
 
       def spec
         environment.kubernetes
+      end
+
+      def generate_hash(data)
+        Digest::SHA1.hexdigest(data)
       end
     end
   end


### PR DESCRIPTION
Hello, I'm planning to use this method for implementing hash generation in particular providers as follows

```ruby
def kubeconfig_path
  File.join(
    kubeconfig_dir,
    "#{environment.app_name.downcase}" \
    "-#{generate_hash(config.access_token + config.cluster_id)}" \
    "-kubeconfig.yaml"
  )
end
```

Also, I created PR for digital ocean provider (https://github.com/getkuby/kuby-digitalocean/pull/3)
So if the implementation is ok, let me know and I will do it for other providers too

(this PR is a part of https://github.com/getkuby/kuby-core/issues/40)
