### PR TITLE
Fix handling Rails/Rake options in remote exec

### DIFF
--- a/lib/kuby/commands.rb
+++ b/lib/kuby/commands.rb
@@ -25,7 +25,7 @@ module Kuby
       def run(args)
         if idx = args.index('rails') || idx = args.index('rake')
           @rails_options = T.let(@rails_options, T.nilable(T::Array[String]))
-          @rails_options = args[idx..-1]
+          @rails_options = args[(idx+1)..-1]
           super(args[0..idx])
         else
           super
@@ -164,7 +164,7 @@ module Kuby
       rc.desc 'Runs an arbitrary command inside a running Rails pod.'
       rc.command :exec do |c|
         c.action do |global_options, options, args|
-          tasks.remote_exec(args)
+          tasks.remote_exec(args + @rails_options)
         end
       end
 

--- a/scripts/integration.sh
+++ b/scripts/integration.sh
@@ -170,4 +170,7 @@ curl -vvv $ingress_ip:80 \
   --connect-timeout 5 \
   --max-time 10 \
   --retry 5 \
-  --retry-max-time 40
+  --retry-max-time 40 || exit $?
+
+# execute remote command
+GLI_DEBUG=true bundle exec kuby -e production remote exec "bundle exec rails runner 'puts \"Hello from Kuby\"'" | grep "Hello from Kuby"


### PR DESCRIPTION
Currently, running `kuby remote exec "bundle exec rails whatever"` strips out everything after "rails"/"rake".

This PR fixes this (tested locally) as well as adds an integration test for running remote commands.