### PR TITLE
Add bundler_phase.gemfiles(*paths) to allow adding additional gemfiles

### DIFF
--- a/lib/kuby/docker/bundler_phase.rb
+++ b/lib/kuby/docker/bundler_phase.rb
@@ -35,6 +35,7 @@ module Kuby
 
         @version = T.let(@version, T.nilable(String))
         @gemfile = T.let(@gemfile, T.nilable(String))
+        @gemfiles = T.let([], T::Array[String])
         @without = T.let(@without, T.nilable(T::Array[String]))
       end
 
@@ -51,6 +52,10 @@ module Kuby
         dockerfile.copy(gf, '.')
         dockerfile.copy(lf, '.')
 
+        @gemfiles.each do |file|
+          dockerfile.copy(file, file)
+        end
+
         unless wo.empty?
           dockerfile.env("BUNDLE_WITHOUT='#{wo.join(' ')}'")
         end
@@ -65,6 +70,11 @@ module Kuby
         # generate binstubs and add the bin directory to our path
         dockerfile.run('bundle', 'binstubs', '--all')
         dockerfile.env("PATH=./bin:$PATH")
+      end
+
+      sig { params(paths: String).void }
+      def gemfiles(*paths)
+        @gemfiles.concat(paths)
       end
 
       private

--- a/spec/docker/spec_spec.rb
+++ b/spec/docker/spec_spec.rb
@@ -107,6 +107,18 @@ describe Kuby::Docker::Spec do
         expect(subject).to match(/RUN bundle install .* --gemfile foo\/bar\/Gemfile/)
       end
     end
+
+    context 'when multiple gemfiles are specified' do
+      before { spec.bundler_phase.gemfiles('gemfiles/a.gemfile', 'gemfiles/b.gemfile') }
+
+      it 'uses all gemfiles including the default one' do
+        expect(subject).to include("COPY Gemfile .\n")
+        expect(subject).to include("COPY Gemfile.lock .\n")
+        expect(subject).to include("COPY gemfiles/a.gemfile gemfiles/a.gemfile\n")
+        expect(subject).to include("COPY gemfiles/b.gemfile gemfiles/b.gemfile\n")
+        expect(subject).to match(/RUN bundle install .* --gemfile Gemfile/)
+      end
+    end
   end
 
   describe '#package' do


### PR DESCRIPTION
This is useful when you have some deps extracted into their own gemfiles and use eval_gemfile in the main Gemfile.

Example:

```ruby
# Gemfile
...

eval_gemfile "gemfiles/kuby.gemfile"

# gemfiles/kuby.gemfile
gem 'kuby-core', '< 1.0'
gem 'kuby-digitalocean', '< 1.0'
```

Then in `kuby.rb`:

```rb
docker do
  bundler_phase.gemfiles "gemfiles/kuby.gemfile"
end
```
