### PR TITLE
Make RAILS_MASTER_KEY available in the assets image

### DIFF
--- a/lib/kuby/plugins/rails_app/assets.rb
+++ b/lib/kuby/plugins/rails_app/assets.rb
@@ -317,14 +317,15 @@ module Kuby
             tags.each_cons(2) do |prev_tag, tag|
               prev_image_name = "#{app_name}-#{prev_tag}"
               df.from("#{base_image.image_url}:#{prev_tag}", as: prev_image_name)
+              df.arg('RAILS_MASTER_KEY')
               df.run("mkdir -p #{RAILS_MOUNT_PATH}")
-              df.run("bundle exec rake kuby:rails_app:assets:copy")
+              df.run("env RAILS_MASTER_KEY=$RAILS_MASTER_KEY bundle exec rake kuby:rails_app:assets:copy")
 
               if tag
                 image_name = "#{app_name}-#{tag}"
                 df.from("#{base_image.image_url}:#{tag}", as: image_name)
                 df.copy("--from=#{prev_image_name} #{RAILS_MOUNT_PATH}", RAILS_MOUNT_PATH)
-                df.run("bundle exec rake kuby:rails_app:assets:copy")
+                df.run("env RAILS_MASTER_KEY=$RAILS_MASTER_KEY bundle exec rake kuby:rails_app:assets:copy")
               end
             end
 


### PR DESCRIPTION
Follow-up for #14.

Currently, `RUN bundle exec rake kuby:rails_app:assets:copy` fails with `Missing encryption key to decrypt file with` (due to `Kuby.load!` in initializer).

Not sure that's the right solution (using master key in the assets container); it would be better to avoid requiring credentials for copying assets, but that' would be a much bigger change.

A temporary workaround is to avoid raising on missing credentials:

```ruby
ActiveSupport::EncryptedConfiguration.new(
  config_path: "./config/credentials/production.yml.enc",
  key_path: "./config/credentials/production.key",
  env_key: "RAILS_MASTER_KEY",
  raise_if_missing_key: false
) || {}
```