### PR TITLE
Add docker build args support and image filtering

### DIFF
--- a/docs/docs/after_the_deploy.md
+++ b/docs/docs/after_the_deploy.md
@@ -51,11 +51,25 @@ Print out all the Dockerfiles:
 bundle exec kuby -e production dockerfiles
 ```
 
+You can also show a Dockerfile for a particular image (using its identifier):
+
+```bash
+bundle exec kuby -e production dockerfiles --only app
+```
+
 Print out all your Kubernetes configs:
 
 ```bash
 bundle exec kuby -e production resources
 ```
+
+You can also specify Kind and/or Name filters:
+
+```bash
+bundle exec kuby -e production resources --kind service --name ".+-(web|rpc)"
+```
+
+NOTE: `--kind` uses the exact match and `--name` accepts regular expressions.
 
 Run an arbitrary kubectl command:
 

--- a/docs/docs/customizing_docker_build.md
+++ b/docs/docs/customizing_docker_build.md
@@ -120,7 +120,7 @@ You can pass additional build args via the `-a` (`--arg`) flag. For example, you
 bundle exec kuby build -a SOURCE_COMMIT=$COMMIT_SHA
 ```
 
-**NOTE:** You should take care of adding `ARG SOURCE_COMMIT` and `ENV SOURCE_COMMIT=$SOURCE_COMMIT` yourself (see above).
+**NOTE:** You will need to add `ARG SOURCE_COMMIT` and `ENV SOURCE_COMMIT=$SOURCE_COMMIT` to the Dockerfile yourself (see above).
 
 By default, `kuby build` builds all the registered Docker images. Sometimes it could be useful to build a particular one. For that, you can use the `--only` option:
 

--- a/docs/docs/customizing_docker_build.md
+++ b/docs/docs/customizing_docker_build.md
@@ -114,6 +114,31 @@ end
 
 ## Docker build options
 
+You can pass additional build args via the `-a` (`--arg`) flag. For example, you can add a current Git commit info to a container:
+
+```bash
+bundle exec kuby build -a SOURCE_COMMIT=$COMMIT_SHA
+```
+
+**NOTE:** You should take care of adding `ARG SOURCE_COMMIT` and `ENV SOURCE_COMMIT=$SOURCE_COMMIT` yourself (see above).
+
+By default, `kuby build` builds all the registered Docker images. Sometimes it could be useful to build a particular one. For that, you can use the `--only` option:
+
+```bash
+bundle exec kuby build --only app
+```
+
+The value for the `--only` option is an image identifier. You can see it in the output of the `kuby dockerfiles` command:
+
+```bash
+$ bundle exec kuby dockerfiles
+
+Dockerfile for #app image my.registry/my/app with tags 20211119151614, latest
+...
+```
+
+A similar option is available for the `push` and `dockerfiles` commands, e.g., `kuby push --only app`.
+
 You can also provide arbitrary options to the `docker build` command:
 
 ```bash

--- a/docs/docs/customizing_docker_build.md
+++ b/docs/docs/customizing_docker_build.md
@@ -111,3 +111,17 @@ end
 1. `copy(source, dest, from: nil)`
 1. `expose(port)`
 1. `cmd(command)`
+
+## Docker build options
+
+You can also provide arbitrary options to the `docker build` command:
+
+```bash
+bundle exec kuby build -- [options]
+```
+
+For example, you can specify a [custom build target](https://docs.docker.com/engine/reference/commandline/build/#custom-build-outputs):
+
+```bash
+bundle exec kuby build -- --output type=tar,dest=out.tar
+```

--- a/lib/kuby/commands.rb
+++ b/lib/kuby/commands.rb
@@ -65,6 +65,7 @@ module Kuby
     desc 'Builds the Docker image.'
     command :build do |c|
       c.flag [:a, :arg], required: false, multiple: true
+      c.flag [:only], required: false
       c.action do |global_options, options, args|
         build_args = {}.tap do |build_args|
           (options[:arg] || []).each do |a|
@@ -74,14 +75,15 @@ module Kuby
           end
         end
 
-        tasks.build(build_args, args)
+        tasks.build(build_args, args, options[:only])
       end
     end
 
     desc 'Pushes the Docker image to the configured registry.'
     command :push do |c|
+      c.flag [:only], required: false
       c.action do |global_options, options, args|
-        tasks.push
+        tasks.push(options[:only])
       end
     end
 
@@ -94,8 +96,9 @@ module Kuby
 
     desc 'Prints the effective Dockerfiles used to build Docker images.'
     command :dockerfiles do |c|
+      c.flag [:only], required: false
       c.action do |global_options, options, args|
-        tasks.print_dockerfiles
+        tasks.print_dockerfiles(options[:only])
       end
     end
 

--- a/lib/kuby/commands.rb
+++ b/lib/kuby/commands.rb
@@ -120,8 +120,10 @@ module Kuby
 
     desc 'Prints the effective Kubernetes resources that will be applied on deploy.'
     command :resources do |c|
+      c.flag [:K, :kind], required: false
+      c.flag [:N, :name], required: false
       c.action do |global_options, options, args|
-        tasks.print_resources
+        tasks.print_resources(options[:kind], options[:name])
       end
     end
 

--- a/lib/kuby/commands.rb
+++ b/lib/kuby/commands.rb
@@ -74,7 +74,7 @@ module Kuby
           end
         end
 
-        tasks.build(build_args)
+        tasks.build(build_args, args)
       end
     end
 

--- a/lib/kuby/commands.rb
+++ b/lib/kuby/commands.rb
@@ -66,7 +66,7 @@ module Kuby
     command :build do |c|
       c.flag [:a, :arg], required: false, multiple: true
       c.flag [:only], required: false
-      c.action do |global_options, options, args|
+      c.action do |global_options, options, docker_args|
         build_args = {}.tap do |build_args|
           (options[:arg] || []).each do |a|
             key, value = a.split('=', 2)
@@ -75,7 +75,7 @@ module Kuby
           end
         end
 
-        tasks.build(build_args, args, options[:only])
+        tasks.build(build_args, docker_args, options[:only])
       end
     end
 

--- a/lib/kuby/docker/app_image.rb
+++ b/lib/kuby/docker/app_image.rb
@@ -6,13 +6,13 @@ module Kuby
     class AppImage < ::Kuby::Docker::TimestampedImage
       extend T::Sig
 
-      sig { params(build_args: T::Hash[String, String]).returns(AppImage) }
-      def build(build_args = {})
+      sig { params(build_args: T::Hash[String, String], args: T::Array[String]).returns(AppImage) }
+      def build(build_args = {}, args = [])
         unless ENV.fetch('RAILS_MASTER_KEY', '').empty?
           build_args['RAILS_MASTER_KEY'] = T.must(ENV['RAILS_MASTER_KEY'])
         end
 
-        super(build_args)
+        super(build_args, args)
       end
     end
   end

--- a/lib/kuby/docker/app_image.rb
+++ b/lib/kuby/docker/app_image.rb
@@ -20,13 +20,13 @@ module Kuby
         @identifier = "app"
       end
 
-      sig { params(build_args: T::Hash[String, String], args: T::Array[String]).returns(AppImage) }
-      def build(build_args = {}, args = [])
+      sig { params(build_args: T::Hash[String, String], docker_args: T::Array[String]).returns(AppImage) }
+      def build(build_args = {}, docker_args = [])
         unless ENV.fetch('RAILS_MASTER_KEY', '').empty?
           build_args['RAILS_MASTER_KEY'] = T.must(ENV['RAILS_MASTER_KEY'])
         end
 
-        super(build_args, args)
+        super(build_args, docker_args)
       end
     end
   end

--- a/lib/kuby/docker/app_image.rb
+++ b/lib/kuby/docker/app_image.rb
@@ -6,6 +6,20 @@ module Kuby
     class AppImage < ::Kuby::Docker::TimestampedImage
       extend T::Sig
 
+      sig {
+        params(
+          dockerfile: T.any(Dockerfile, T.proc.returns(Dockerfile)),
+          image_url: String,
+          credentials: Credentials,
+          main_tag: T.nilable(String),
+          alias_tags: T::Array[String]
+        ).void
+      }
+      def initialize(dockerfile, image_url, credentials, main_tag = nil, alias_tags = [])
+        super
+        @identifier = "app"
+      end
+
       sig { params(build_args: T::Hash[String, String], args: T::Array[String]).returns(AppImage) }
       def build(build_args = {}, args = [])
         unless ENV.fetch('RAILS_MASTER_KEY', '').empty?

--- a/lib/kuby/docker/cli.rb
+++ b/lib/kuby/docker/cli.rb
@@ -53,8 +53,8 @@ module Kuby
         config.fetch('auths', {}).keys
       end
 
-      sig { params(image: Image, build_args: T::Hash[T.any(Symbol, String), String], args: T::Array[String]).void }
-      def build(image, build_args: {}, args: [])
+      sig { params(image: Image, build_args: T::Hash[T.any(Symbol, String), String], docker_args: T::Array[String]).void }
+      def build(image, build_args: {}, docker_args: [])
         cmd = [
           executable, 'build',
           *image.tags.flat_map { |tag| ['-t', "#{image.image_url}:#{tag}"] },
@@ -62,7 +62,7 @@ module Kuby
             ['--build-arg', Shellwords.shellescape("#{arg}=#{val}")]
           end,
           '-f-',
-          *args,
+          *docker_args,
           '.'
         ]
 

--- a/lib/kuby/docker/cli.rb
+++ b/lib/kuby/docker/cli.rb
@@ -53,15 +53,17 @@ module Kuby
         config.fetch('auths', {}).keys
       end
 
-      sig { params(image: Image, build_args: T::Hash[T.any(Symbol, String), String]).void }
-      def build(image, build_args: {})
+      sig { params(image: Image, build_args: T::Hash[T.any(Symbol, String), String], args: T::Array[String]).void }
+      def build(image, build_args: {}, args: [])
         cmd = [
           executable, 'build',
           *image.tags.flat_map { |tag| ['-t', "#{image.image_url}:#{tag}"] },
           *build_args.flat_map do |arg, val|
             ['--build-arg', Shellwords.shellescape("#{arg}=#{val}")]
           end,
-          '-f-', '.'
+          '-f-',
+          *args,
+          '.'
         ]
 
         open3_w(cmd) do |stdin, _wait_threads|

--- a/lib/kuby/docker/image.rb
+++ b/lib/kuby/docker/image.rb
@@ -89,8 +89,8 @@ module Kuby
         [main_tag, *alias_tags].compact
       end
 
-      sig { params(build_args: T::Hash[String, String]).void }
-      def build(build_args = {})
+      sig { params(build_args: T::Hash[String, String], args: T::Array[String]).void }
+      def build(build_args = {}, args = [])
         raise NotImplementedError, 'please use a Docker::Image subclass'
       end
 

--- a/lib/kuby/docker/image.rb
+++ b/lib/kuby/docker/image.rb
@@ -93,8 +93,8 @@ module Kuby
         [main_tag, *alias_tags].compact
       end
 
-      sig { params(build_args: T::Hash[String, String], args: T::Array[String]).void }
-      def build(build_args = {}, args = [])
+      sig { params(build_args: T::Hash[String, String], docker_args: T::Array[String]).void }
+      def build(build_args = {}, docker_args = [])
         raise NotImplementedError, 'please use a Docker::Image subclass'
       end
 

--- a/lib/kuby/docker/image.rb
+++ b/lib/kuby/docker/image.rb
@@ -5,6 +5,9 @@ module Kuby
     class Image
       extend T::Sig
 
+      sig { returns(T.nilable(String)) }
+      attr_reader :identifier
+
       sig { returns(String) }
       attr_reader :image_url
 
@@ -32,6 +35,7 @@ module Kuby
         @credentials = T.let(credentials, Credentials)
         @main_tag = T.let(main_tag, T.nilable(String))
         @alias_tags = T.let(alias_tags, T::Array[String])
+        @identifier = T.let(@identifier, T.nilable(String))
 
         @image_host = T.let(@image_host, T.nilable(String))
         @image_hostname = T.let(@image_hostname, T.nilable(String))

--- a/lib/kuby/docker/timestamped_image.rb
+++ b/lib/kuby/docker/timestamped_image.rb
@@ -73,9 +73,9 @@ module Kuby
         tag
       end
 
-      sig { params(build_args: T::Hash[String, String], args: T::Array[String]).void }
-      def build(build_args = {}, args = [])
-        docker_cli.build(new_version, build_args: build_args, args: args)
+      sig { params(build_args: T::Hash[String, String], docker_args: T::Array[String]).void }
+      def build(build_args = {}, docker_args = [])
+        docker_cli.build(new_version, build_args: build_args, docker_args: docker_args)
         @current_version = new_version
         @new_version = nil
       end

--- a/lib/kuby/docker/timestamped_image.rb
+++ b/lib/kuby/docker/timestamped_image.rb
@@ -73,9 +73,9 @@ module Kuby
         tag
       end
 
-      sig { params(build_args: T::Hash[String, String]).void }
-      def build(build_args = {})
-        docker_cli.build(new_version, build_args: build_args)
+      sig { params(build_args: T::Hash[String, String], args: T::Array[String]).void }
+      def build(build_args = {}, args = [])
+        docker_cli.build(new_version, build_args: build_args, args: args)
         @current_version = new_version
         @new_version = nil
       end

--- a/lib/kuby/plugins/rails_app/assets_image.rb
+++ b/lib/kuby/plugins/rails_app/assets_image.rb
@@ -27,8 +27,8 @@ module Kuby
           )
         end
 
-        def build(build_args = {})
-          docker_cli.build(current_version, build_args: build_args)
+        def build(build_args = {}, args = [])
+          docker_cli.build(current_version, build_args: build_args, args: args)
         end
 
         def push(tag)

--- a/lib/kuby/plugins/rails_app/assets_image.rb
+++ b/lib/kuby/plugins/rails_app/assets_image.rb
@@ -7,6 +7,7 @@ module Kuby
         def initialize(base_image, dockerfile, main_tag = nil, alias_tags = [])
           super(dockerfile, base_image.image_url, base_image.credentials, main_tag, alias_tags)
           @base_image = base_image
+          @identifier = "assets"
         end
 
         def new_version

--- a/lib/kuby/plugins/rails_app/assets_image.rb
+++ b/lib/kuby/plugins/rails_app/assets_image.rb
@@ -28,8 +28,8 @@ module Kuby
           )
         end
 
-        def build(build_args = {}, args = [])
-          docker_cli.build(current_version, build_args: build_args, args: args)
+        def build(build_args = {}, docker_args = [])
+          docker_cli.build(current_version, build_args: build_args, docker_args: docker_args)
         end
 
         def push(tag)

--- a/lib/kuby/tasks.rb
+++ b/lib/kuby/tasks.rb
@@ -84,10 +84,16 @@ module Kuby
       environment.kubernetes.rollback
     end
 
-    def print_resources
+    def print_resources(kind = nil, name_pattern = nil)
       kubernetes.before_deploy
 
+      name_rxp = Regexp.new(name_pattern) if name_pattern
+
       kubernetes.resources.each do |res|
+        next if kind && res.kind_sym.to_s != kind
+
+        next if name_rxp && !name_rxp.match?(res.metadata.name)
+
         puts res.to_resource.serialize.to_yaml
       end
     end

--- a/lib/kuby/tasks.rb
+++ b/lib/kuby/tasks.rb
@@ -9,10 +9,13 @@ module Kuby
       @environment = environment
     end
 
-    def print_dockerfiles
+    def print_dockerfiles(only = nil)
       kubernetes.docker_images.each do |image|
+        next if only && image.identifier != only
+
         image = image.current_version
-        Kuby.logger.info("Dockerfile for image #{image.image_url} with tags #{image.tags.join(', ')}")
+        identifier = image.identifier ? " ##{image.identifier}" : ""
+        Kuby.logger.info("Dockerfile for#{identifier} image #{image.image_url} with tags #{image.tags.join(', ')}")
         theme = Rouge::Themes::Base16::Solarized.new
         formatter = Rouge::Formatters::Terminal256.new(theme)
         lexer = Rouge::Lexers::Docker.new
@@ -25,16 +28,20 @@ module Kuby
       environment.kubernetes.setup
     end
 
-    def build(build_args = {}, args = [])
+    def build(build_args = {}, args = [], only = nil)
       kubernetes.docker_images.each do |image|
+        next if only && image.identifier != only
+
         image = image.new_version
         Kuby.logger.info("Building image #{image.image_url} with tags #{image.tags.join(', ')}")
         image.build(build_args, args)
       end
     end
 
-    def push
+    def push(only = nil)
       kubernetes.docker_images.each do |image|
+        next if only && image.identifier != only
+
         image = image.current_version
         Kuby.logger.info("Pushing image #{image.image_url} with tags #{image.tags.join(', ')}")
         push_image(image)

--- a/lib/kuby/tasks.rb
+++ b/lib/kuby/tasks.rb
@@ -28,13 +28,13 @@ module Kuby
       environment.kubernetes.setup
     end
 
-    def build(build_args = {}, args = [], only = nil)
+    def build(build_args = {}, docker_args = [], only = nil)
       kubernetes.docker_images.each do |image|
         next if only && image.identifier != only
 
         image = image.new_version
         Kuby.logger.info("Building image #{image.image_url} with tags #{image.tags.join(', ')}")
-        image.build(build_args, args)
+        image.build(build_args, docker_args)
       end
     end
 

--- a/lib/kuby/tasks.rb
+++ b/lib/kuby/tasks.rb
@@ -25,11 +25,11 @@ module Kuby
       environment.kubernetes.setup
     end
 
-    def build(build_args = {})
+    def build(build_args = {}, args = [])
       kubernetes.docker_images.each do |image|
         image = image.new_version
         Kuby.logger.info("Building image #{image.image_url} with tags #{image.tags.join(', ')}")
-        image.build(build_args)
+        image.build(build_args, args)
       end
     end
 


### PR DESCRIPTION
This PR enhance `kuby build` functionality:
- Allows adding additional (arbitrary) args to `docker build`
- Adds identifiers to images and `--only` flag to build only the selected image (also added to `push` and `dockerfiles`).

Added filtering to `resources`:

```sh
bundle exec kuby -e production resources --kind service --name ".+-(web|rpc)"
```

Why?

Here is my example use case—faster deploys on GitHub Actions:

```yml
- name: Build and push Docker images
   run: |
     bundle exec kuby -e production build --only app --    --cache-from=type=gha,scope=app --cache-to=type=gha,scope=app,mode=max --push
     bundle exec kuby -e production build --only assets -- --cache-from=type=gha,scope=assets --cache-to=type=gha,scope=assets,mode=max --push
```

First, we need to make it possible to specify `--cache-from` and `--cache-to` options. That's why I added `args` support.

Then, for this particular use case, we need to use different cache names for different images (otherwise the last one wins, or overwrites the cache, making it useless).

_"Maybe, you should use plain `docker build` then?"_

Nope. Kuby takes care of build args and all other stuff I don't want to think about 🙂
