### PR TITLE
add RAILS_MASTER_KEY to subsequent dockerfile

### DIFF
--- a/lib/kuby/plugins/rails_app/assets.rb
+++ b/lib/kuby/plugins/rails_app/assets.rb
@@ -324,6 +324,7 @@ module Kuby
               if tag
                 image_name = "#{app_name}-#{tag}"
                 df.from("#{base_image.image_url}:#{tag}", as: image_name)
+                df.arg('RAILS_MASTER_KEY')
                 df.copy("--from=#{prev_image_name} #{RAILS_MOUNT_PATH}", RAILS_MOUNT_PATH)
                 df.run("env RAILS_MASTER_KEY=$RAILS_MASTER_KEY bundle exec rake kuby:rails_app:assets:copy")
               end


### PR DESCRIPTION
Unsure if this was omitted in error

I was unable to push images without this change, I got obscure errors like "404 not found" and other red herrings that were masking the issue.

Eventually I found in the docker build logs, one instance of the RAILS_MASTER_KEY echoed out into the terminal, and a second instance which was not echoed and appeared to be substituting the literal `$RAILS_MASTER_KEY`

```
#13 ERROR: executor failed running [/bin/sh -c env RAILS_MASTER_KEY=$RAILS_MASTER_KEY bundle exec rake kuby:rails_app:assets:copy]: exit code: 1
------
 > [kubytest-20211206142301 3/3] RUN env RAILS_MASTER_KEY=$RAILS_MASTER_KEY bundle exec rake kuby:rails_app:assets:copy:
```

I made this one line change in my installed `kuby-core` gem which made it possible to get through this step:

```
bundle exec kuby -e production build
```

I have still managed to be stuck on subsequent steps, and wonder if there's a more appropriate forum that I could try for one-off "how does it work" type questions - I originally hoped to use the Azure provider but I was unable to meet the requirements, now I've switched to Digital Ocean and nearly have it working 🎉