### PR TITLE
Ensure that RAILS_MASTER_KEY is available at assets precompiling time

### DIFF
--- a/lib/kuby/plugins/rails_app/assets_image.rb
+++ b/lib/kuby/plugins/rails_app/assets_image.rb
@@ -29,6 +29,10 @@ module Kuby
         end
 
         def build(build_args = {}, docker_args = [])
+          unless ENV.fetch('RAILS_MASTER_KEY', '').empty?
+            build_args['RAILS_MASTER_KEY'] = ENV['RAILS_MASTER_KEY']
+          end
+
           docker_cli.build(current_version, build_args: build_args, docker_args: docker_args)
         end
 


### PR DESCRIPTION
When following the advice that I got here:

* https://github.com/getkuby/kuby-core/issues/76#issuecomment-993357872

I decided to split my build for app and assets this way: `kuby build --only app` and `kuby build --only assets` so that I could accommodate the use of buildx for caching, which requires each image built to be assigned a separate caching scope... (otherwise, the act of serially building "app" and "assets" is problematic in some subtle ways, that are worth documenting... suffice it to say the "assets" image shadowing the "app" image cache appears to very nearly nuke the cache each time, but with them split properly the caching is very effective!)

Anyway, I found that `RAILS_MASTER_KEY` was not being passed in `build_args` anymore, when the assets image is built by itself. With some strategically placed `binding.pry` statements and inspections of `caller` I was able to trace the execution – it looks like this (borrowed from `lib/kuby/docker/app_image.rb`) needs to be included here?

I noticed that you added type signatures in some of the files, but not this one. I would love to learn to use sorbet and I'm happy to take feedback on this PR, if there's something you'd like me to add before merging this.

I'm certainly willing to change it however you want! I'm using this in my test app now, from the master branch of my own fork, (so there's no rush to merge this and get a release out on my account.)