### PR TITLE
'which' is deprecated in Debian sid

### DIFF
--- a/kuby-core.gemspec
+++ b/kuby-core.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'kube-dsl', '~> 0.4'
   s.add_dependency 'kuby-kube-db', '>= 0.6'
   s.add_dependency 'kubernetes-cli', '~> 0.3'
+  s.add_dependency 'ptools', '~> 1.4'
   s.add_dependency 'railties', '>= 5.1'
   s.add_dependency 'rouge', '~> 3.0'
   s.add_dependency 'sorbet-runtime-stub', '~> 0.2'

--- a/lib/kuby/docker/cli.rb
+++ b/lib/kuby/docker/cli.rb
@@ -2,6 +2,7 @@
 
 require 'json'
 require 'open3'
+require 'ptools'
 require 'shellwords'
 
 module Kuby
@@ -14,7 +15,7 @@ module Kuby
 
       sig { params(executable: T.nilable(String)).void }
       def initialize(executable = nil)
-        @executable = T.let(executable || `which docker`.strip, String)
+        @executable = T.let(executable || File.which('docker'), String)
       end
 
       sig { returns(T.nilable(String)) }


### PR DESCRIPTION
I did some research and it seems there is no canonical implementation of Which in ruby standard lib proper, but there is ptools that adds which to the File class. This is really tricky to diagnose, because they didn't just soft-deprecate it, (it seems it has been replaced with a non-functioning version that emits the warning instead of the path to the target, or at least the emitting of the warning seems to have side-effects that were hard to trace back from my recollection...)

So for users who have this issue on their systems, it manifests as unexplained failure and this is basically the only thing I found particularly worthy of sending back as a PR, from the changes I made in my fork! HTH