### PR TITLE
FIX Unknown alias: default (Psych::BadAlias)

### DIFF
--- a/lib/kuby/plugins/rails_app/database.rb
+++ b/lib/kuby/plugins/rails_app/database.rb
@@ -51,7 +51,11 @@ module Kuby
         end
 
         def db_configs
-          @db_configs ||= YAML.load(File.read(db_config_path))
+          @db_configs ||= begin
+            YAML.load(File.read(db_config_path), aliases: true)
+          rescue ArgumentError
+            YAML.load(File.read(db_config_path))
+          end
         end
 
         def db_config_path

--- a/lib/kuby/plugins/rails_app/database.rb
+++ b/lib/kuby/plugins/rails_app/database.rb
@@ -1,6 +1,5 @@
 # typed: false
 require 'yaml'
-require 'pry'
 
 module Kuby
   module Plugins

--- a/lib/kuby/plugins/rails_app/database.rb
+++ b/lib/kuby/plugins/rails_app/database.rb
@@ -1,5 +1,6 @@
 # typed: false
 require 'yaml'
+require 'pry'
 
 module Kuby
   module Plugins
@@ -52,9 +53,11 @@ module Kuby
 
         def db_configs
           @db_configs ||= begin
-            YAML.load(File.read(db_config_path), aliases: true)
-          rescue ArgumentError
-            YAML.load(File.read(db_config_path))
+            if Psych::VERSION > '4'
+              YAML.load(File.read(db_config_path), aliases: true)
+            else ArgumentError
+              YAML.load(File.read(db_config_path))
+            end
           end
         end
 


### PR DESCRIPTION
Ruby 3.0 comes with Psych 3, while Ruby 3.1 comes with Psych 4, which has a major breaking change.
1. The new YAML loading methods (Psych 4) do not load aliases unless they get the aliases: true argument.
2. The old YAML loading methods (Psych 3) do not support the aliases keyword.

This change is breaking the codebase while loading the database.yml and this PR handles that for ruby 3.1.x