### PR TITLE
Docs: Move app_phase example to the App Phase section

### DIFF
--- a/docs/docs/customizing_docker_build.md
+++ b/docs/docs/customizing_docker_build.md
@@ -134,11 +134,11 @@ The copy phase copies your app's source code into the Docker image.
 
 The app phase allows setting environment variables. These variables will be available to any commands run afterwards in the `docker build` process, but will also be accessible to your application via Ruby's `ENV` hash.
 
+* `app_phase.env(key: String, value: String)`: Adds an environment variable.
+
 ### Assets Phase
 
 The assets phase compiles static assets managed by both the asset pipeline and Webpacker.
-
-* `app_phase.env(key: String, value: String)`: Adds an environment variable.
 
 ### Webserver Phase
 


### PR DESCRIPTION
Thanks for creating Kuby! I was reading through the docs and noticed this line in a section it didn't seem to belong in. This must have gotten misplaced in a previous edit.