### PR TITLE
Add support to configure the number of web workers for puma

### DIFF
--- a/docs/docs/customizing_docker_build.md
+++ b/docs/docs/customizing_docker_build.md
@@ -145,6 +145,7 @@ The assets phase compiles static assets managed by both the asset pipeline and W
 The webserver phase instructs the Docker image to use a webserver to run your app. Currently only the Rails default, [Puma](https://github.com/puma/puma), is supported (including puma in your Gemfile is all you need to do - no other configuration is necessary).
 
 * `webserver_phase.port = Integer`: Sets the port the webserver should listen on.
+* `webserver_phase.workers = Integer`: Sets the number of webserver workers to spawn. Defaults to 4.
 * `webserver_phase.webserver = Symbol`: Sets the webserver to use. Must be `:puma`. Additional webservers may be supported in the future if there is demand. The only reason to set this field manually is if Kuby can't detect Puma in your Gemfile for some reason.
 
 ## Creating A Custom Build Phase

--- a/lib/kuby/docker/webserver_phase.rb
+++ b/lib/kuby/docker/webserver_phase.rb
@@ -46,7 +46,7 @@ module Kuby
       T::Sig::WithoutRuntime.sig { params(port: Integer).returns(Integer) }
       attr_writer :port
 
-      T::Sig::WithoutRuntime.sig { params(port: Integer).returns(Integer) }
+      T::Sig::WithoutRuntime.sig { params(workers: Integer).returns(Integer) }
       attr_writer :workers
 
       T::Sig::WithoutRuntime.sig { returns(T.nilable(Symbol)) }
@@ -78,6 +78,7 @@ module Kuby
         @port || DEFAULT_PORT
       end
 
+      T::Sig::WithoutRuntime.sig { returns(Integer) }
       def workers
         @workers || DEFAULT_WORKERS
       end

--- a/lib/kuby/docker/webserver_phase.rb
+++ b/lib/kuby/docker/webserver_phase.rb
@@ -28,7 +28,7 @@ module Kuby
         def apply_to(dockerfile)
           dockerfile.cmd(
             'puma',
-            '--workers', '4',
+            '--workers', phase.workers.to_s,
             '--bind', 'tcp://0.0.0.0',
             '--port', phase.port.to_s,
             '--pidfile', './server.pid',
@@ -40,10 +40,14 @@ module Kuby
       end
 
       DEFAULT_PORT = T.let(8080, Integer)
+      DEFAULT_WORKERS = T.let(4, Integer)
       WEBSERVER_MAP = T.let({ puma: Puma }.freeze, T::Hash[Symbol, T.class_of(Webserver)])
 
       T::Sig::WithoutRuntime.sig { params(port: Integer).returns(Integer) }
       attr_writer :port
+
+      T::Sig::WithoutRuntime.sig { params(port: Integer).returns(Integer) }
+      attr_writer :workers
 
       T::Sig::WithoutRuntime.sig { returns(T.nilable(Symbol)) }
       attr_reader :webserver
@@ -56,6 +60,7 @@ module Kuby
         super
 
         @port = T.let(@port, T.nilable(Integer))
+        @workers = T.let(@workers, T.nilable(Integer))
         @webserver = T.let(@webserver, T.nilable(Symbol))
       end
 
@@ -71,6 +76,10 @@ module Kuby
       T::Sig::WithoutRuntime.sig { returns(Integer) }
       def port
         @port || DEFAULT_PORT
+      end
+
+      def workers
+        @workers || DEFAULT_WORKERS
       end
 
       private


### PR DESCRIPTION
This PR fixes an issue my team was having with resource consumption for non production environments, with two replicas and 4 workers per replica an app that operates at 500MB of memory usage consumes 4GB. I've added an option to specify the number of workers that puma spawns so users have more granular control over their webservers and their resource consumption. I've left the default number of workers at 4 to prevent any breaking changes to user's configs.