### PR TITLE
Attempt to use Python3 in integration tests (node dependency)

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -30,7 +30,7 @@ jobs:
           node-version: '16'
       - uses: actions/setup-python@v4
         with:
-          python-version: '2.7.x'
+          python-version: '3.x'
       - name: Install Bundler
         run: gem install bundler
       - name: Install Kind


### PR DESCRIPTION
Actions [no longer offers](https://github.com/actions/setup-python/issues/672) Python 2.x, which is a node dependency. Node uses the gyp build system for native extensions, which is written in Python. Fortunately it sounds like Python 3 is supported as of node v13, so we should be able to use a much more modern Python in our integration tests.